### PR TITLE
Handle URLs that don't end in .git

### DIFF
--- a/lib/brah.rb
+++ b/lib/brah.rb
@@ -20,7 +20,10 @@ module Brah
     private
 
       def convert_ssh_to_http(git_remote_output)
-        git_remote_output.match(/origin\t(.+)\.git/)[1].gsub("com:", "com/").gsub("git@", "https://")
+        git_remote_output.match(/origin\t(\S+)/)[1].
+          gsub(/\.git$/, "").
+          gsub("com:", "com/").
+          gsub("git@", "https://")
       end
   end
 end

--- a/test/brah_test.rb
+++ b/test/brah_test.rb
@@ -59,6 +59,26 @@ class BrahTest < Minitest::Test
     assert brah.run, "Expected brah.run to be true, but it was false"
   end
 
+  def test_when_public_remote_does_not_end_with_dot_git
+    git_remote_without_dot_git = "origin\tgit@github.com:trayo/brah (fetch)"
+
+    brah = Brah::Brah.new(git_remote_without_dot_git)
+    brah.expects(:system).with("open #{PUBLIC_URL}").returns(true).once
+
+    assert_equal brah.command, "open https://github.com/trayo/brah"
+    assert brah.run, "Expected brah.run to be true, but it was false"
+  end
+
+  def test_when_private_remote_does_not_end_with_dot_git
+    git_remote_without_dot_git = "origin\tgit@github.enterprise.com:trayo/brah (fetch)"
+
+    brah = Brah::Brah.new(git_remote_without_dot_git)
+    brah.expects(:system).with("open #{PRIVATE_URL}").returns(true).once
+
+    assert_equal brah.command, "open https://github.enterprise.com/trayo/brah"
+    assert brah.run, "Expected brah.run to be true, but it was false"
+  end
+
   def test_when_there_are_no_remotes_found
     no_remotes = ""
 


### PR DESCRIPTION
GitHub allows using remote URLs without the `.git` extension. For example:

```
$ git remote -v
origin  git@github.com:ooesili/brah (fetch)
origin  git@github.com:ooesili/brah (push)
```

This commit allows `brah` to handle these URLs.